### PR TITLE
fix: remove duplicate coordinate offset calculation

### DIFF
--- a/www/javascript/rail.js
+++ b/www/javascript/rail.js
@@ -46,21 +46,6 @@ window.initMap = async function() {
         coordMap[key].push(s);
     });
 
-    Object.values(coordMap).forEach(group => {
-        if (group.length === 1) {
-            group[0].displayLat = Number(group[0].lat);
-            group[0].displayLon = Number(group[0].lon);
-        } else {
-            const radius = 0.00015;
-            group.forEach((station, index) => {
-                const angle = (index / group.length) * Math.PI * 2;
-                station.displayLat = Number(station.lat) + (Math.cos(angle) * radius);
-                const latRad = Number(station.lat) * (Math.PI / 180);
-                station.displayLon = Number(station.lon) + ((Math.sin(angle) * radius) / Math.cos(latRad));
-            });
-        }
-    });
-
     allStations = stations;
     lineColors = lines;
     window.allStations = allStations;


### PR DESCRIPTION
## Summary
- Removed a duplicate `displayLat`/`displayLon` offset calculation that ran twice on every map load
- The first pass results were immediately overwritten by the second pass, making it pure wasted work
- Kept only the second pass (which sorts by `line_id` for consistent overlap ordering)

## Background
Inside `initMap` in `rail.js`, the coordinate offset logic for overlapping stations existed in two places (lines 41–62 and 97–112). The only difference was a `sort` call in the second pass. Since the second pass always ran after and overwrote the first, the first pass had no effect.

## Test plan
- [ ] Open the map and confirm station markers render correctly
- [ ] Confirm that stations sharing the same coordinates (e.g. transfer stations) spread apart instead of stacking