### PR TITLE
feat: debounce map idle listener to reduce redundant marker renders

### DIFF
--- a/www/javascript/rail.js
+++ b/www/javascript/rail.js
@@ -74,8 +74,12 @@ window.initMap = async function() {
     initUserTracking();
 
     // Map Event Listeners
+    let idleTimer;
     map.addListener('idle', () => {
-        renderVisibleMarkers(map, allStations, lineColors, activeLineFilter, showTooltip);
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+            renderVisibleMarkers(map, allStations, lineColors, activeLineFilter, showTooltip);
+        }, 150);
     });
 
     map.addListener('dragstart', () => {


### PR DESCRIPTION
## Summary
- Added a 150ms debounce to the `idle` map event listener
- `renderVisibleMarkers` loops all 11,101 stations on every fire — rapid panning/zooming was triggering this repeatedly with no delay
- The marker loop now only runs once the map has settled, cutting unnecessary work significantly on low-end devices

## Why 150ms
Short enough to feel instant after the map stops, long enough to skip intermediate fires during continuous gestures.

## Test plan
- [ ] Pan the map quickly and confirm markers still render correctly after stopping
- [ ] Zoom in/out and confirm markers update after the gesture completes
- [ ] Confirm no visible delay or jank compared to before