### PR TITLE
Fetch Firestore config once and share across all sync functions

### DIFF
--- a/www/javascript/map_utils.js
+++ b/www/javascript/map_utils.js
@@ -1,9 +1,10 @@
 import { db } from './firebase.js';
 import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
 
-export async function syncStationData() {
-    const configRef = doc(db, 'metadata', 'config');
-    const configSnap = await getDoc(configRef);
+export async function syncStationData(configSnap) {
+    if (!configSnap) {
+        configSnap = await getDoc(doc(db, 'metadata', 'config'));
+    }
     const remoteVersion = configSnap.exists() ? configSnap.data().stationVersion : 0;
     const localVersion = localStorage.getItem('stationVersion');
     let localData = localStorage.getItem('stationData');
@@ -21,9 +22,10 @@ export async function syncStationData() {
     return JSON.parse(localData);
 }
 
-export async function syncLineData() {
-    const configRef = doc(db, 'metadata', 'config');
-    const configSnap = await getDoc(configRef);
+export async function syncLineData(configSnap) {
+    if (!configSnap) {
+        configSnap = await getDoc(doc(db, 'metadata', 'config'));
+    }
     const remoteVersion = configSnap.exists() ? configSnap.data().stationVersion : 0;
     const localVersion = localStorage.getItem('lineVersion');
     let localData = localStorage.getItem('lineData');
@@ -51,9 +53,10 @@ export async function syncLineData() {
     return JSON.parse(localData);
 }
 
-export async function syncJoinData() {
-    const configRef = doc(db, 'metadata', 'config');
-    const configSnap = await getDoc(configRef);
+export async function syncJoinData(configSnap) {
+    if (!configSnap) {
+        configSnap = await getDoc(doc(db, 'metadata', 'config'));
+    }
     const remoteVersion = configSnap.exists() ? configSnap.data().stationVersion : 0;
     const localVersion = localStorage.getItem('joinVersion');
     let localData = localStorage.getItem('joinData');

--- a/www/javascript/rail.js
+++ b/www/javascript/rail.js
@@ -1,4 +1,6 @@
 import { syncStationData, syncLineData, syncJoinData } from './map_utils.js';
+import { db } from './firebase.js';
+import { doc, getDoc } from 'firebase/firestore';
 import { renderPolylines, polylines } from './map_layers.js';
 import { renderVisibleMarkers, updateUserMarker } from './map_markers.js';
 import { toggleStation } from './user.js';
@@ -32,10 +34,12 @@ window.initMap = async function() {
     window.map = map;
 
     // Load Data from Firestore/Cache
+    // Fetch config once and share it across all sync functions to avoid 3 redundant round trips
+    const configSnap = await getDoc(doc(db, 'metadata', 'config'));
     const [stations, lines, joins] = await Promise.all([
-        syncStationData(),
-        syncLineData(),
-        syncJoinData()
+        syncStationData(configSnap),
+        syncLineData(configSnap),
+        syncJoinData(configSnap)
     ]);
 
     // Handle overlapping stations (same Lat/Lon)


### PR DESCRIPTION
## Summary
- `syncStationData`, `syncLineData`, and `syncJoinData` each made a separate `getDoc` call to `metadata/config` on startup — 3 round trips to Firestore for the same document
- Now fetches the config once in `rail.js` and passes it to all three functions
- Each sync function keeps a fallback `getDoc` so they still work if called standalone

## Impact
Reduces startup Firestore reads from 4 to 2 (1 config + 3 collections → 1 config + 3 collections, but the config is now shared). On a cold cache this saves 2 network round trips before any station data is shown.

## Test plan
- [x] Hard refresh (clear localStorage via Refresh button) and confirm all stations, lines, and joins load correctly
- [x] Confirm cached load (second visit) still works without hitting Firestore