### PR TITLE
fix: cannot move to map from settings by clicking map icon

### DIFF
--- a/www/javascript/ui.js
+++ b/www/javascript/ui.js
@@ -61,10 +61,12 @@ export function initButtons() {
 
     if (heartBtn) {
         heartBtn.onclick = function() {
-            const isAnyFrameOpen = 
+            const settingsContainer = document.getElementById("settings-container");
+            const isAnyFrameOpen =
                 !feedContainer.classList.contains("-translate-x-full") ||
-                !listContainer.classList.contains("translate-x-full") || 
-                (profileContainer && !profileContainer.classList.contains("translate-x-full"));
+                !listContainer.classList.contains("translate-x-full") ||
+                (profileContainer && !profileContainer.classList.contains("translate-x-full")) ||
+                (settingsContainer && !settingsContainer.classList.contains("-translate-x-full"));
 
             if (!isAnyFrameOpen) {
                 window.centerOnUser?.();


### PR DESCRIPTION
## Summary

- Settings panel was not included in the `isAnyFrameOpen` check in the map icon click handler
- When settings was open, clicking the map icon called `centerOnUser()` instead of `resetUI()`, leaving the settings panel open

## Fix

Added settings container to the open-state check so clicking the map icon correctly closes the settings panel.

Closes #28