### PR TITLE
fix: hide map tooltip when navigating to other panels

### DIFF
--- a/www/javascript/rail.js
+++ b/www/javascript/rail.js
@@ -283,6 +283,7 @@ export function hideTooltip() {
         window.activeStationId = null;
     }
 }
+window.hideTooltip = hideTooltip;
 
 document.addEventListener('DOMContentLoaded', () => {
     const cancelUnmarkBtn = document.getElementById('cancel-unmark-btn');

--- a/www/javascript/ui.js
+++ b/www/javascript/ui.js
@@ -33,6 +33,8 @@ export function initButtons() {
         listBtn.classList.remove("bg-[#40C4FF]");
         listIcon.classList.remove("text-white");
         listIcon.classList.add("text-[#40C4FF]");
+
+        window.hideTooltip?.();
     }
 
     window.resetUI = resetUI;


### PR DESCRIPTION
## Summary

- Station and line tooltips now close when opening feed, list, profile, or settings panels
- Exposed `hideTooltip` on `window` in `rail.js` so `ui.js` can call it without a circular import
- Called `window.hideTooltip?.()` inside `resetUI()` in `ui.js`

Closes #21