### PR TITLE
fix: station markers not rendering after refresh

### DIFF
--- a/www/javascript/rail.js
+++ b/www/javascript/rail.js
@@ -104,6 +104,9 @@ window.initMap = async function() {
         renderVisibleMarkers(map, allStations, lineColors, activeLineFilter, showTooltip);
     });
 
+    // idle has already fired by the time data loads, so render immediately
+    renderVisibleMarkers(map, allStations, lineColors, activeLineFilter, showTooltip);
+
     map.addListener('dragstart', () => {
         isFollowingUser = false;
         hideTooltip();


### PR DESCRIPTION
## Summary

The map `idle` event fires when tiles first load — before the Firebase data fetch completes. By the time the `idle` listener is registered, the event has already fired, so markers only appear after the next pan/zoom.

## Fix

Call `renderVisibleMarkers()` directly after data loads, in addition to keeping the `idle` listener for subsequent interactions.

Closes #20