### PR TITLE
fix(auth): remove required attribute when hiding fields after Google login

### DIFF
--- a/www/javascript/auth.js
+++ b/www/javascript/auth.js
@@ -177,8 +177,8 @@ export function initAuth() {
                             authUsername.placeholder = "Choose a Username";
                         }
                         
-                        if(authIdentifier) authIdentifier.classList.add('hidden');
-                        if(authPassword) authPassword.classList.add('hidden');
+                        if(authIdentifier) { authIdentifier.classList.add('hidden'); authIdentifier.required = false; }
+                        if(authPassword) { authPassword.classList.add('hidden'); authPassword.required = false; }
                         if(authGoogleBtn) authGoogleBtn.classList.add('hidden');
                         if(authAnonBtn) authAnonBtn.classList.add('hidden');
                         if(authToggleMode) authToggleMode.classList.add('hidden');


### PR DESCRIPTION
## Summary
- After Google sign-in, email and password fields are hidden but `required` attribute remained, causing browser form validation errors
- Added `required = false` when hiding `auth-identifier` and `auth-password` fields

## Test plan
- [ ] Sign in with Google
- [ ] Enter username and click Save Username
- [ ] Confirm no form validation error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)