### PR TITLE
fix(profile): re-init profile frame after auth resolves to show correct username

### DIFF
--- a/www/javascript/auth.js
+++ b/www/javascript/auth.js
@@ -114,7 +114,8 @@ export function initAuth() {
                     setCurrentUser(user.uid, username, user.isAnonymous);
                     initProfileSync();
                     initFeedFrame();
-                    
+                    window.dispatchEvent(new CustomEvent('authResolved'));
+
                 } else if (!user.isAnonymous) {
                     const emailQuery = query(collection(db, 'users'), where("email", "==", user.email));
                     const emailSnap = await getDocs(emailQuery);
@@ -160,6 +161,7 @@ export function initAuth() {
                         setCurrentUser(user.uid, username, user.isAnonymous);
                         initProfileSync();
                         initFeedFrame();
+                        window.dispatchEvent(new CustomEvent('authResolved'));
                     } else {
                         authContainer.style.transition = 'none';
                         authContainer.classList.remove('hidden', 'translate-y-full');
@@ -228,6 +230,7 @@ export function initAuth() {
                     setCurrentUser(user.uid, username, user.isAnonymous);
                     initProfileSync();
                     initFeedFrame();
+                    window.dispatchEvent(new CustomEvent('authResolved'));
                 }
             } catch (e) {
             }

--- a/www/javascript/profile.js
+++ b/www/javascript/profile.js
@@ -174,3 +174,7 @@ document.addEventListener('turbo:frame-load', (e) => {
         initProfileFrame();
     }
 });
+
+window.addEventListener('authResolved', () => {
+    initProfileFrame();
+});


### PR DESCRIPTION
## Summary
- After Google sign-in, `initProfileFrame()` was called before Firebase resolved the auth state, so `auth.currentUser` was null and the profile displayed "Guest"
- Added `authResolved` custom event dispatched from `auth.js` after auth completes
- `profile.js` listens to `authResolved` and re-runs `initProfileFrame()` to show the correct username

## Root cause
`turbo:frame-load` fires immediately on page load before Firebase auth resolves. `initFeedFrame()` was already being called after auth, but `initProfileFrame()` was not.

## Test plan
- [ ] Sign in with Google
- [ ] Open profile panel
- [ ] Confirm username is shown instead of "Guest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)