### PR TITLE
fix(feed): show error message when post submission fails

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -559,6 +559,7 @@
                     <input type="hidden" id="post-station-id-hidden">
                 </div>
                 </div>
+                <p id="post-submit-error" class="hidden text-center text-[#FF5252] font-bold text-sm"></p>
                 <button id="submit-post-btn" data-i18n="post.postIt" class="w-full bg-[#FF80AB] border-[5px] border-black rounded-2xl py-4 text-black font-black text-2xl uppercase tracking-tighter shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] active:translate-y-[6px] active:translate-x-[6px] active:shadow-none transition-all mt-4">
                     Post It!
                 </button>

--- a/www/javascript/feed.js
+++ b/www/javascript/feed.js
@@ -369,8 +369,11 @@ document.addEventListener('DOMContentLoaded', () => {
             const caption = document.getElementById('post-caption-input').value.trim();
             const tag = document.getElementById('post-tag-input').value;
             const stationId = document.getElementById('post-station-id-hidden').value;
+            const errorEl = document.getElementById('post-submit-error');
             let stationName = '';
-            
+
+            if (errorEl) errorEl.classList.add('hidden');
+
             if (stationId && window.allStations) {
                 const s = window.allStations.find(x => String(x.id) === String(stationId));
                 if (s) stationName = s.station_name_en || s.station_name_jp;
@@ -391,8 +394,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 commentsCount: 0
             };
 
-            await addDoc(collection(db, 'posts'), postData);
-            document.getElementById('create-post-container').classList.add('translate-y-full', 'pointer-events-none');
+            submitBtn.disabled = true;
+            try {
+                await addDoc(collection(db, 'posts'), postData);
+                document.getElementById('create-post-container').classList.add('translate-y-full', 'pointer-events-none');
+            } catch (err) {
+                if (errorEl) {
+                    errorEl.innerText = 'Failed to post. Please check your connection and try again.';
+                    errorEl.classList.remove('hidden');
+                }
+            } finally {
+                submitBtn.disabled = false;
+            }
         };
     }
 


### PR DESCRIPTION
## Summary
- Post submission had no error handling — if Firestore write failed (permission error, data too large, etc.), the screen would freeze with no feedback
- Added try/catch around `addDoc` with an error message element
- Button is disabled during submission to prevent duplicate posts

## Test plan
- [ ] Submit a post normally — confirm it works
- [ ] Temporarily add `throw new Error()` before `addDoc` — confirm error message appears
- [ ] Confirm button re-enables after error

🤖 Generated with [Claude Code](https://claude.com/claude-code)