### PR TITLE
fix(map): close popup when user zooms in or out

### DIFF
--- a/www/javascript/rail.js
+++ b/www/javascript/rail.js
@@ -134,6 +134,8 @@ window.initMap = async function() {
         hideTooltip();
     });
 
+    map.addListener('zoom_changed', hideTooltip);
+
     map.addListener('click', hideTooltip);
 
     document.getElementById('map-tooltip').addEventListener('click', async (e) => {


### PR DESCRIPTION
## Summary
- ズーム操作時（スクロールホイール・ピンチズーム・ズームボタン）にマップのポップアップを閉じるようにした
- `zoom_changed` イベントリスナーを追加し、既存の `dragstart` / `click` と同様のパターンで `hideTooltip()` を呼び出す

## Test plan
- [ ] 駅マーカーをクリックしてポップアップを表示 → ズームイン/アウトでポップアップが閉じることを確認
- [ ] 路線をクリックしてポップアップを表示 → ズームイン/アウトでポップアップが閉じることを確認
- [ ] スクロールホイール・ピンチズーム・ズームボタンすべてで動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)