### PR TITLE
fix(list): force re-fetch prefectures/companies if Japanese names missing in cache

### DIFF
--- a/www/javascript/list.js
+++ b/www/javascript/list.js
@@ -18,14 +18,22 @@ async function initList() {
     let prefs = await idbGet('prefecturesData');
     let comps = await idbGet('companiesData');
 
-    if (!prefs || !comps) {
+    // Force re-fetch if cached data is missing Japanese names (stale cache).
+    // TODO: remove this guard after all clients have refreshed stale caches (post-deploy).
+    const hasJapanesePrefNames = prefs && prefs.some(p =>
+        p.pref_name_jp && /[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff]/.test(p.pref_name_jp)
+    );
+    const hasJapaneseCompNames = comps && comps.some(c =>
+        c.company_name_jp && /[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff]/.test(c.company_name_jp)
+    );
+    if (!prefs || !comps || !hasJapanesePrefNames || !hasJapaneseCompNames) {
         const [prefSnap, compSnap] = await Promise.all([
             getDocs(collection(db, 'prefectures')),
             getDocs(collection(db, 'companies'))
         ]);
         prefs = prefSnap.docs.map(d => ({ id: d.id, ...d.data() }));
         comps = compSnap.docs.map(d => ({ id: d.id, ...d.data() }));
-        
+
         await idbSet('prefecturesData', prefs);
         await idbSet('companiesData', comps);
     }


### PR DESCRIPTION
## Summary
- Added a cache guard to force re-fetch prefectures and companies from Firestore when Japanese names are missing from cached data
- Follows the same pattern as `hasJapaneseLineNames` in `rail.js`
- Firestore documents have already been updated with `pref_name_jp` and `company_name_jp` fields

## Test plan
- [ ] Prefecture dropdown shows Japanese names in Japanese mode
- [ ] Company dropdown shows Japanese names in Japanese mode
- [ ] Re-fetch is triggered for users with stale cached data

🤖 Generated with [Claude Code](https://claude.com/claude-code)