### PR TITLE
fix(settings): preserve Firebase auth session when refreshing data cache

### DIFF
--- a/www/javascript/settings.js
+++ b/www/javascript/settings.js
@@ -270,13 +270,25 @@ export function initSettingsFrame() {
                     const dark = localStorage.getItem(DARK_MODE_KEY);
                     const sound = localStorage.getItem(SOUND_KEY);
                     const decline = localStorage.getItem(DECLINE_REQUESTS_KEY);
-                    
+
+                    // Preserve Firebase Auth session tokens so the user is not logged out
+                    const firebaseEntries = {};
+                    for (let i = 0; i < localStorage.length; i++) {
+                        const key = localStorage.key(i);
+                        if (key && key.startsWith('firebase:')) {
+                            firebaseEntries[key] = localStorage.getItem(key);
+                        }
+                    }
+
                     localStorage.clear();
-                    
+
                     if (lang) localStorage.setItem(LANG_KEY, lang);
                     if (dark) localStorage.setItem(DARK_MODE_KEY, dark);
                     if (sound) localStorage.setItem(SOUND_KEY, sound);
                     if (decline) localStorage.setItem(DECLINE_REQUESTS_KEY, decline);
+                    for (const [key, val] of Object.entries(firebaseEntries)) {
+                        localStorage.setItem(key, val);
+                    }
 
                     await idbClear();
                 } catch (err) {}


### PR DESCRIPTION
## Summary

- Fixes #55: "Refresh Data" button was calling `localStorage.clear()` which removed Firebase Auth session tokens, logging the user out on web
- Firebase Auth on web uses `browserLocalPersistence`, storing tokens under keys prefixed with `firebase:`
- Before clearing, we now snapshot all `firebase:` keys and restore them after — same pattern already used for language, dark mode, and sound settings

## Changes

- `settings.js`: Save and restore `firebase:` prefixed localStorage keys around the `localStorage.clear()` call in the refresh button handler
- Sign out and delete account flows are intentionally left unchanged (they should clear auth state)

## Test plan

- [ ] Sign in to the app on web
- [ ] Go to Settings and click "Refresh Data"
- [ ] Confirm the app reloads and the user remains logged in
- [ ] Confirm station/line cache data is refreshed from Firestore after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)