### PR TITLE
feat(i18n): rename feed title in Japanese from フィード to ソーシャル

### DIFF
--- a/www/javascript/i18n.js
+++ b/www/javascript/i18n.js
@@ -229,7 +229,7 @@ export const translations = {
             unmarkMsg: "この駅の訪問済みマークを解除してもよろしいですか？"
         },
         feed: {
-            title: "フィード",
+            title: "ソーシャル",
             all: "すべて",
             friends: "フレンド",
             addPost: "+ 投稿",


### PR DESCRIPTION
## Summary

- Fixes #71: Japanese feed label changed from 「フィード」 to 「ソーシャル」
- Single-line change in `i18n.js` (`ja.feed.title`)

## Changes

- `www/javascript/i18n.js`: `"フィード"` → `"ソーシャル"`

## Test plan

- [ ] Switch language to Japanese and confirm the Feed tab/header shows 「ソーシャル」
- [ ] Switch to English and confirm it still shows "Feed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)