### PR TITLE
disallow take a picture if camera is missing

### DIFF
--- a/www/javascript/list_detail.js
+++ b/www/javascript/list_detail.js
@@ -160,6 +160,17 @@ export function initStampScanner() {
     const deleteConfirmModal = document.getElementById("delete-confirm-modal");
     const deleteConfirmBox = document.getElementById("delete-confirm-box");
 
+    const captureStampBtn = document.getElementById("capture-stamp-btn");
+
+    function setCaptureEnabled(btn, enabled) {
+        btn.disabled = !enabled;
+        if (enabled) {
+            btn.classList.remove('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+        } else {
+            btn.classList.add('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+        }
+    }
+
     selectors.detailStationsList.addEventListener('click', e => {
         const btn = e.target.closest('.add-stamp-btn');
         if (btn) {
@@ -167,7 +178,10 @@ export function initStampScanner() {
             els.pill.innerText = btn.dataset.stationName;
             els.pill.style.backgroundColor = btn.dataset.lineColor;
             els.addCont.classList.remove("translate-y-full", "pointer-events-none");
-            startCamera(els.video, els.place, loadOpenCV);
+            setCaptureEnabled(captureStampBtn, true);
+            startCamera(els.video, els.place, loadOpenCV).then(stream => {
+                setCaptureEnabled(captureStampBtn, !!stream);
+            });
             return;
         }
         

--- a/www/javascript/model_ui.js
+++ b/www/javascript/model_ui.js
@@ -23,7 +23,8 @@ export function initModelUI(refreshCallback) {
         modalCont: document.getElementById("model-modal-container"),
         modalImg: document.getElementById("model-modal-image"),
         modalName: document.getElementById("model-modal-name"),
-        modalDate: document.getElementById("model-modal-date")
+        modalDate: document.getElementById("model-modal-date"),
+        captureBtn: document.getElementById("capture-model-btn")
     };
 
     const deleteModelConfirmModal = document.getElementById("delete-model-confirm-modal");
@@ -47,7 +48,10 @@ export function initModelUI(refreshCallback) {
                 pendingModelImageData = null;
 
                 modelEls.addCont.classList.remove("translate-y-full", "pointer-events-none");
-                startCamera(modelEls.video, modelEls.place, async () => {});
+                setCaptureEnabled(modelEls.captureBtn, true);
+                startCamera(modelEls.video, modelEls.place, async () => {}).then(stream => {
+                    setCaptureEnabled(modelEls.captureBtn, !!stream);
+                });
                 return;
             }
 
@@ -122,7 +126,10 @@ export function initModelUI(refreshCallback) {
         modelEls.previewImg.src = '';
         modelEls.captureActions.classList.remove('hidden');
         modelEls.saveActions.classList.add('hidden');
-        startCamera(modelEls.video, modelEls.place, async () => {});
+        setCaptureEnabled(modelEls.captureBtn, true);
+        startCamera(modelEls.video, modelEls.place, async () => {}).then(stream => {
+            setCaptureEnabled(modelEls.captureBtn, !!stream);
+        });
     };
 
     document.getElementById("save-model-btn").onclick = async () => {
@@ -199,6 +206,15 @@ export function initModelUI(refreshCallback) {
         modelEls.modalCont.classList.add('opacity-0', 'pointer-events-none');
         refreshCallback();
     };
+
+    function setCaptureEnabled(btn, enabled) {
+        btn.disabled = !enabled;
+        if (enabled) {
+            btn.classList.remove('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+        } else {
+            btn.classList.add('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+        }
+    }
 
     function resizeCanvasImage(canvas, maxSize) {
         if (canvas.width > maxSize || canvas.height > maxSize) {

--- a/www/javascript/stamp_ui.js
+++ b/www/javascript/stamp_ui.js
@@ -41,6 +41,17 @@ export function initStampUI(refreshCallback) {
     const deleteConfirmModal = document.getElementById("delete-confirm-modal");
     const deleteConfirmBox = document.getElementById("delete-confirm-box");
 
+    const captureStampBtn = document.getElementById("capture-stamp-btn");
+
+    function setCaptureEnabled(btn, enabled) {
+        btn.disabled = !enabled;
+        if (enabled) {
+            btn.classList.remove('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+        } else {
+            btn.classList.add('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+        }
+    }
+
     selectors.detailStationsList.addEventListener('click', e => {
         const btn = e.target.closest('.add-stamp-btn');
         if (btn) {
@@ -48,7 +59,10 @@ export function initStampUI(refreshCallback) {
             els.pill.innerText = btn.dataset.stationName;
             els.pill.style.backgroundColor = btn.dataset.lineColor;
             els.addCont.classList.remove("translate-y-full", "pointer-events-none");
-            startCamera(els.video, els.place, loadOpenCV);
+            setCaptureEnabled(captureStampBtn, true);
+            startCamera(els.video, els.place, loadOpenCV).then(stream => {
+                setCaptureEnabled(captureStampBtn, !!stream);
+            });
             return;
         }
         


### PR DESCRIPTION
<img width="495" height="818" alt="image" src="https://github.com/user-attachments/assets/d542c3b1-352f-4526-80c5-e103615eb69f" />
Current state, you can press the capture button, and it will return null. So, this PR is to prevent it by grey it out the button