### PR TITLE
fix(auth): remove premature authResolved dispatch during profile setup

### DIFF
--- a/www/javascript/auth.js
+++ b/www/javascript/auth.js
@@ -211,7 +211,6 @@ export function initAuth() {
                         if(titleEl) titleEl.innerText = "Complete Profile";
                         
                         if(authSubmitBtn) authSubmitBtn.innerText = "Save Username";
-window.dispatchEvent(new CustomEvent('authResolved'));
                         authForm.onsubmit = async (e) => {
                             e.preventDefault();
                             if(errorMsg) errorMsg.classList.add('hidden');


### PR DESCRIPTION
## Summary

- Removes the early `authResolved` dispatch that fired before the user had saved their username on the "Complete Profile" screen
- The loading overlay now correctly stays visible during profile setup and is removed only after the post-save reload completes the normal auth flow

## Root cause

`authResolved` was dispatched at `auth.js:214` before `authForm.onsubmit` was even assigned, causing `main.js` to remove the loading overlay and `profile.js` to call `initProfileFrame()` — both while `setCurrentUser` / `initFeedFrame` had not yet been called.

After `window.location.reload()` on successful username save, `onAuthStateChanged` re-runs through the normal path (user has a username now) and dispatches `authResolved` at line 130 with full user state established.

## Test plan

- [ ] New Google sign-in (first-time, no username): confirm loading overlay stays up during "Complete Profile" screen
- [ ] Save username → page reloads → overlay removes normally and feed loads
- [ ] Existing user login: unaffected, overlay removes as before
- [ ] Anonymous user: unaffected

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)